### PR TITLE
Match the mime type of the search suggestions example to the Suggestions extension specification.

### DIFF
--- a/opensearch-1-1-draft-6.md
+++ b/opensearch-1-1-draft-6.md
@@ -276,7 +276,7 @@ starting with element index 0:*
 JSON:*
 
 ```xml
-<Url type="application/json"
+<Url type="application/x-suggestions+json"
      rel="suggestions"
      template="http://example.com/suggest?q={searchTerms}" />
 ```


### PR DESCRIPTION
Currently the MIME type of the search suggestions example in [the URL element](https://github.com/dewitt/opensearch/blob/cf4fb8c157f4ba4b6ccd04dfeeeec32d85621e5b/opensearch-1-1-draft-6.md#the-url-element) section gives a MIME type of "application/json".

It would be better if this was "application/x-suggestions+json" as that would match the [Suggestions extension](http://www.opensearch.org/Specifications/OpenSearch/Extensions/Suggestions#Type).

Reported by feluchs via https://bugzilla.mozilla.org/show_bug.cgi?id=1425827