### PR TITLE
Link to latest parameter draft

### DIFF
--- a/mediawiki/Specifications/OpenSearch/Extensions/Parameter.wiki
+++ b/mediawiki/Specifications/OpenSearch/Extensions/Parameter.wiki
@@ -1,1 +1,1 @@
-#REDIRECT [[Specifications/OpenSearch/Extensions/Parameter/1.0/Draft_1]]
+#REDIRECT [[Specifications/OpenSearch/Extensions/Parameter/1.0/Draft_2]]

--- a/mediawiki/Specifications/OpenSearch/Extensions/Parameter/1.0.wiki
+++ b/mediawiki/Specifications/OpenSearch/Extensions/Parameter/1.0.wiki
@@ -1,1 +1,1 @@
-#REDIRECT [[Specifications/OpenSearch/Extensions/Parameter/1.0/Draft 1]]
+#REDIRECT [[Specifications/OpenSearch/Extensions/Parameter/1.0/Draft 2]]


### PR DESCRIPTION
The draft 2 is the one being used by the OpenSearch Servers from NASA and ESA
e.g. fedeo.esa.int
https://fedeo.esa.int/opensearch/description.xml
Also is the recommended in the [Best Practice Document](http://ceos.org/document_management/Working_Groups/WGISS/Interest_Groups/OpenSearch/CEOS-OPENSEARCH-BP-V1.2.pdf) of the Committee on Earth Observation Satellites (CEOS) 

CEOS-BP-002 - Support of OpenSearch Parameter Extension (Draft 2) [Recommended]  