### PR TITLE
Use backticks instead of quotes

### DIFF
--- a/opensearch-1-1-draft-6.md
+++ b/opensearch-1-1-draft-6.md
@@ -50,7 +50,7 @@
     - [The `startPage` parameter](#the-startpage-parameter)
     - [The `language` parameter](#the-language-parameter)
     - [The `inputEncoding` parameter](#the-inputencoding-parameter)
-    - [The "outputEncoding" parameter](#the-outputencoding-parameter)
+    - [The `outputEncoding` parameter](#the-outputencoding-parameter)
 - [OpenSearch `Query` element](#opensearch-query-element)
   - [Overview](#overview)
   - [Examples](#examples)


### PR DESCRIPTION
Fix a second instance of quotes instead of backticks around the outputEncoding parameter name.